### PR TITLE
Add styling to hovering example

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,26 +137,26 @@
       <section class="mt-16">
         <h2 class="text-xl mb-2 mt-8">With remote content</h2>
         <div data-controller="popover" data-popover-url-value="/card.html">
-          This is my Github card available on
+          This is my GitHub card available on
           <a
             href="https://github.com/stimulus-components/stimulus-popover"
             class="relative"
             data-action="mouseover->popover#show mouseout->popover#hide"
           >
-            Github </a
-          >.
+            <span class="text-blue-600 no-underline hover:underline">GitHub</span></a
+          >
         </div>
 
         <h2 class="text-xl mb-2 mt-8">With local template</h2>
         <div data-controller="popover">
-          This is my Github card available on
+          This is my GitHub card available on
           <a
             href="https://github.com/stimulus-components/stimulus-popover"
             class="relative"
             data-action="mouseover->popover#show mouseout->popover#hide"
           >
-            Github </a
-          >.
+            <span class="text-blue-600 no-underline hover:underline">GitHub</span></a
+          >
 
           <template data-popover-target="content">
             <div


### PR DESCRIPTION
Hi @guillaumebriday,

Thank you for great work with all the stimulus-components stuff! 🥇 

Recently, I've tried to play around with the https://stimulus-popover.netlify.app and realize that I spent 30 seconds to try to understand where I should move my cursor to get a popup :)

So, I propose to update the example in some way:

1) Colorize the needed word
2) Add an underline on a hover link (like it works in GitHub originally)
3) Remove a dot at the end of the sentence, IMO the whole example looks better without it
4) Update `Github` to `GitHub` according to proper Organization name

### Before:

<img width="619" alt="before" src="https://user-images.githubusercontent.com/641426/104366759-8abfb280-5522-11eb-9aa3-01a3a7de5c6e.png">

### After:
<img width="626" alt="after" src="https://user-images.githubusercontent.com/641426/104366744-8398a480-5522-11eb-9dac-567930342317.png">

Feel free to merge it all or pick the liked one from a proposition, thank you!